### PR TITLE
Apply workaround to other top-level elements

### DIFF
--- a/_sass/_tufte-extra.scss
+++ b/_sass/_tufte-extra.scss
@@ -22,6 +22,16 @@ article > p, article > footer, article > table { width: 55%; }
 article > ol, article > ul { width: 50%;
                              -webkit-padding-start: 5%; }
 
+@media (max-width: 760px) {
+    article > p, article > footer, article > table {
+        width: 100%;
+    }
+
+    article > ol, article > ul {
+        width: 90%;
+    }
+}
+
 /*
  * Enable hyphens on supported platforms
  */

--- a/_sass/_tufte-extra.scss
+++ b/_sass/_tufte-extra.scss
@@ -16,9 +16,11 @@ body { max-width: 1150px; }
 /**
  * Makes it so that top-level <p> don't need to be wrapped in <section>
  */
-article > p {
-  width: 55%;
-}
+article > p, article > footer, article > table { width: 55%; }
+
+/* 50 + 5 == 55, to be the same width as paragraph */
+article > ol, article > ul { width: 50%;
+                             -webkit-padding-start: 5%; }
 
 /*
  * Enable hyphens on supported platforms


### PR DESCRIPTION
Tufte.css sets width for `section > p` etc to enable sidenotes: https://github.com/jez/tufte-pandoc-jekyll/blob/15cfe2eef9885912175e6f626d763de991765403/_sass/_tufte.scss#L94-L98

This file previously had a workaround to not require section tags at the top level, but it only worked for <p> elements. This change copies over all the changes from the base tufte.css so that it works for all elements.

## Testing done

Manually added a css rule in my chrome inspector for `article > ul { width: 50% }` and saw content rendered correctly.

Added header_include for this:
https://github.com/awreece/manager138/blob/fbe41ca2619c5d1fd840f738ad0e2e8906ef90f3/_config.yml#L18-L32